### PR TITLE
Point updateURL at github

### DIFF
--- a/youscrobbler.user.js
+++ b/youscrobbler.user.js
@@ -13,7 +13,7 @@
 // @grant         GM_setValue
 // @grant         GM_xmlhttpRequest
 // @downloadURL   https://raw.githubusercontent.com/floblik/YouScrobbler/master/youscrobbler.user.js
-// @updateURL     http://youscrobbler.lukash.de/youscrobbler.meta.js
+// @updateURL     https://raw.githubusercontent.com/floblik/YouScrobbler/master/youscrobbler.user.js
 // @version       1.4.6
 // @noframes
 // @run-at        document-idle


### PR DESCRIPTION
The current updateURL doesn't seem to be updated when new versions are created (because it has do be done manually?).

Point it directly at github instead, since it's supported to point updateURL at the full script.

In order for all existing installs to get this change, the file at the old url (http://youscrobbler.lukash.de/youscrobbler.meta.js) would have to be updated one last time with a version that contains this change.